### PR TITLE
Add region as a variable to role template

### DIFF
--- a/iam-role-policy.json.tpl
+++ b/iam-role-policy.json.tpl
@@ -24,7 +24,7 @@
             ],
             "Condition": {
                 "StringEquals": {
-                    "kms:ViaService": "s3.us-east-1.amazonaws.com"
+                    "kms:ViaService": "s3.${region}.amazonaws.com"
                 },
                 "StringLike": {
                     "kms:EncryptionContext:aws:s3:arn": "${arn_s3}/*"

--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,7 @@ data "template_file" "iam_role_policy" {
   vars = {
     arn_kms = local.arn_kms
     arn_s3  = local.arn_s3
+    region  = var.region
   }
 }
 


### PR DESCRIPTION
The `us-east-1` region was hard-coded, this PR fix that by using the `region` variable.